### PR TITLE
#22 initera eslint prettier på frontend

### DIFF
--- a/.github/workflows/frontendLint.yaml
+++ b/.github/workflows/frontendLint.yaml
@@ -1,0 +1,18 @@
+defaults:
+    run:
+        working-directory: ./frontend
+
+name: Check code with ESLint on Frontend
+on:
+    pull_request:
+    push:
+jobs:
+    lint:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checks out the latest Git commit
+              uses: actions/checkout@v2
+            - name: Sets up a Node.js environment
+              uses: actions/setup-node@v2
+            - run: npm ci
+            - run: npx eslint -c .eslintrc.json --max-warnings 0 .

--- a/.github/workflows/frontendPrettier.yaml
+++ b/.github/workflows/frontendPrettier.yaml
@@ -1,0 +1,18 @@
+defaults:
+    run:
+        working-directory: ./frontend
+
+name: Check code with Prettier on Frontend
+on:
+    pull_request:
+    push:
+jobs:
+    prettier:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checks out the latest Git commit
+              uses: actions/checkout@v2
+            - name: Sets up a Node.js environment
+              uses: actions/setup-node@v2
+            - run: npm ci
+            - run: npx prettier --config .prettierrc.js -l "*.{tsx,ts}"

--- a/.github/workflows/frontendPrettier.yaml
+++ b/.github/workflows/frontendPrettier.yaml
@@ -15,4 +15,4 @@ jobs:
             - name: Sets up a Node.js environment
               uses: actions/setup-node@v2
             - run: npm ci
-            - run: npx prettier --config .prettierrc -l .
+            - run: npx prettier --config .prettierrc -l "src/**/*.{js,jsx,tsx,ts}\""

--- a/.github/workflows/frontendPrettier.yaml
+++ b/.github/workflows/frontendPrettier.yaml
@@ -15,4 +15,4 @@ jobs:
             - name: Sets up a Node.js environment
               uses: actions/setup-node@v2
             - run: npm ci
-            - run: npx prettier --config .prettierrc.js -l "*.{tsx,ts}"
+            - run: npx prettier --config .prettierrc -l .

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,28 @@
+{
+    "env": {
+        "browser": true,
+        "es2021": true
+    },
+    "extends": [
+        "eslint:recommended",
+        "plugin:react/recommended",
+        "plugin:@typescript-eslint/recommended"
+    ],
+    "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+        "ecmaFeatures": {
+            "jsx": true
+        },
+        "ecmaVersion": "latest",
+        "sourceType": "module"
+    },
+    "plugins": ["react", "@typescript-eslint"],
+    "settings": {
+        "react": {
+            "version": "detect"
+        }
+    },
+    "rules": {
+        "react/react-in-jsx-scope": "off"
+    }
+}

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "semi": true,
+  "tabWidth": 4,
+  "printWidth": 100,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "jsxSingleQuote": true,
+  "bracketSpacing": true
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,18 @@
         "react-scripts": "5.0.1",
         "typescript": "^4.7.3",
         "web-vitals": "^2.1.4"
+      },
+      "devDependencies": {
+        "@typescript-eslint/eslint-plugin": "^5.27.1",
+        "@typescript-eslint/parser": "^5.27.1",
+        "eslint": "^8.17.0",
+        "eslint-config-prettier": "^8.5.0",
+        "eslint-import-resolver-typescript": "^2.7.1",
+        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-prettier": "^4.0.0",
+        "eslint-plugin-react": "^7.30.0",
+        "eslint-plugin-react-hooks": "^4.5.0",
+        "prettier": "^2.6.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -6710,6 +6722,18 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
     "node_modules/eslint-config-react-app": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-7.0.1.tgz",
@@ -6752,6 +6776,26 @@
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.7.1.tgz",
+      "integrity": "sha512-00UbgGwV8bSgUv34igBDbTOtKhqoRMy9bFjNehT40bXg6585PNIct8HhXZ0SybqB9rWtXj9crcku8ndDn/gIqQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4",
+        "glob": "^7.2.0",
+        "is-glob": "^4.0.3",
+        "resolve": "^1.22.0",
+        "tsconfig-paths": "^3.14.1"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*"
       }
     },
     "node_modules/eslint-module-utils": {
@@ -6948,6 +6992,27 @@
       },
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz",
+      "integrity": "sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==",
+      "dev": true,
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.28.0",
+        "prettier": ">=2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint-config-prettier": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-plugin-react": {
@@ -7433,6 +7498,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "dev": true
     },
     "node_modules/fast-glob": {
       "version": "3.2.11",
@@ -13274,6 +13345,33 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/pretty-bytes": {
@@ -21305,6 +21403,13 @@
         }
       }
     },
+    "eslint-config-prettier": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "dev": true,
+      "requires": {}
+    },
     "eslint-config-react-app": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-7.0.1.tgz",
@@ -21343,6 +21448,19 @@
             "ms": "^2.1.1"
           }
         }
+      }
+    },
+    "eslint-import-resolver-typescript": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.7.1.tgz",
+      "integrity": "sha512-00UbgGwV8bSgUv34igBDbTOtKhqoRMy9bFjNehT40bXg6585PNIct8HhXZ0SybqB9rWtXj9crcku8ndDn/gIqQ==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.3.4",
+        "glob": "^7.2.0",
+        "is-glob": "^4.0.3",
+        "resolve": "^1.22.0",
+        "tsconfig-paths": "^3.14.1"
       }
     },
     "eslint-module-utils": {
@@ -21484,6 +21602,15 @@
         "jsx-ast-utils": "^3.2.1",
         "language-tags": "^1.0.5",
         "minimatch": "^3.0.4"
+      }
+    },
+    "eslint-plugin-prettier": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz",
+      "integrity": "sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
       }
     },
     "eslint-plugin-react": {
@@ -21746,6 +21873,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "dev": true
     },
     "fast-glob": {
       "version": "3.2.11",
@@ -25784,6 +25917,21 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
+    },
+    "prettier": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
     },
     "pretty-bytes": {
       "version": "5.6.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,46 +1,60 @@
 {
-  "name": "frontend",
-  "version": "0.1.0",
-  "type": "module",
-  "private": true,
-  "dependencies": {
-    "@testing-library/jest-dom": "^5.16.4",
-    "@testing-library/react": "^13.3.0",
-    "@testing-library/user-event": "^13.5.0",
-    "@types/jest": "^27.5.2",
-    "@types/node": "^16.11.39",
-    "@types/react": "^18.0.12",
-    "@types/react-dom": "^18.0.5",
-    "axios": "^0.27.2",
-    "react": "^18.1.0",
-    "react-dom": "^18.1.0",
-    "react-router-dom": "^6.3.0",
-    "react-scripts": "5.0.1",
-    "typescript": "^4.7.3",
-    "web-vitals": "^2.1.4"
-  },
-  "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject"
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
-  },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  }
+    "name": "frontend",
+    "version": "0.1.0",
+    "type": "module",
+    "private": true,
+    "dependencies": {
+        "@testing-library/jest-dom": "^5.16.4",
+        "@testing-library/react": "^13.3.0",
+        "@testing-library/user-event": "^13.5.0",
+        "@types/jest": "^27.5.2",
+        "@types/node": "^16.11.39",
+        "@types/react": "^18.0.12",
+        "@types/react-dom": "^18.0.5",
+        "axios": "^0.27.2",
+        "react": "^18.1.0",
+        "react-dom": "^18.1.0",
+        "react-router-dom": "^6.3.0",
+        "react-scripts": "5.0.1",
+        "typescript": "^4.7.3",
+        "web-vitals": "^2.1.4"
+    },
+    "scripts": {
+        "start": "react-scripts start",
+        "build": "react-scripts build",
+        "test": "react-scripts test",
+        "eject": "react-scripts eject",
+        "lint": "eslint src/**/*.{js,jsx,ts,tsx,json}",
+        "format": "prettier --write src/**/*.{js,jsx,ts,tsx,css,md,json} --config ./.prettierrc"
+    },
+    "eslintConfig": {
+        "extends": [
+            "react-app",
+            "react-app/jest"
+        ]
+    },
+    "browserslist": {
+        "production": [
+            ">0.2%",
+            "not dead",
+            "not op_mini all"
+        ],
+        "development": [
+            "last 1 chrome version",
+            "last 1 firefox version",
+            "last 1 safari version"
+        ]
+    },
+    "devDependencies": {
+        "@typescript-eslint/eslint-plugin": "^5.27.1",
+        "@typescript-eslint/parser": "^5.27.1",
+        "eslint": "^8.17.0",
+        "eslint-config-prettier": "^8.5.0",
+        "eslint-import-resolver-typescript": "^2.7.1",
+        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-prettier": "^4.0.0",
+        "eslint-plugin-react": "^7.30.0",
+        "eslint-plugin-react-hooks": "^4.5.0",
+        "prettier": "^2.6.2"
+    }
 }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,25 +1,25 @@
 header nav {
-  background: rgb(102, 34, 70);
-  background: linear-gradient(
-    90deg,
-    rgba(102, 34, 70, 1) 0%,
-    rgba(176, 54, 119, 1) 62%,
-    rgba(250, 210, 243, 1) 100%
-  );
-  top: 0;
-  padding: 1em;
+    background: rgb(102, 34, 70);
+    background: linear-gradient(
+        90deg,
+        rgba(102, 34, 70, 1) 0%,
+        rgba(176, 54, 119, 1) 62%,
+        rgba(250, 210, 243, 1) 100%
+    );
+    top: 0;
+    padding: 1em;
 }
 header nav a {
-  margin: 0em 1em;
-  color: white;
-  text-decoration: none;
-  display: inline;
+    margin: 0em 1em;
+    color: white;
+    text-decoration: none;
+    display: inline;
 }
 header nav h1 {
-  font: Avenir;
-  color: white;
+    font: Avenir;
+    color: white;
 }
 
 header nav img {
-  max-height: 4em;
+    max-height: 4em;
 }

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import App from './App';
 
 test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+    render(<App />);
+    const linkElement = screen.getByText(/learn react/i);
+    expect(linkElement).toBeInTheDocument();
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,43 +1,40 @@
-import React, { FC } from "react";
+import React, { FC } from 'react';
 
-import logo from "./logo.svg";
-import SimpleGet from "./Components/SimpleGetRequestTemplate";
+import logo from './logo.svg';
+import SimpleGet from './Components/SimpleGetRequestTemplate';
 
-import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom'
+import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
 
-import "./App.css";
-import Home from '../src/components/Home'
-import MyCourses from '../src/components/MyCourses'
-import logoImage from '../src/images/logoITHS.png'
+import './App.css';
+import Home from '../src/components/Home';
+import MyCourses from '../src/components/MyCourses';
+import logoImage from '../src/images/logoITHS.png';
 
 const App: FC = () => {
-  return (
-    <div className="App">
+    return (
+        <div className='App'>
+            <SimpleGet />
 
-      <SimpleGet />
-    </div>
-  );
-
-      <Router>
-        <header>
-          <nav className='nav'>
-
-            <Link to="/" > <img src={logoImage} alt="logo" /> </Link>
-            <Link to="/" > Hem </Link>
-            <Link to="/courses" > Mina kurser </Link>
-          </nav>
-        </header>
-        <main>
-          <Routes>
-            <Route path="/courses" element={<MyCourses />} />
-            <Route path="/" element={<Home />} />
-          </Routes>
-        </main>
-      </Router>
-
-    </div>
-  )
-
+            <Router>
+                <header>
+                    <nav className='nav'>
+                        <Link to='/'>
+                            {' '}
+                            <img src={logoImage} alt='logo' />
+                        </Link>
+                        <Link to='/'> Hem </Link>
+                        <Link to='/courses'> Mina kurser </Link>
+                    </nav>
+                </header>
+                <main>
+                    <Routes>
+                        <Route path='/courses' element={<MyCourses />} />
+                        <Route path='/' element={<Home />} />
+                    </Routes>
+                </main>
+            </Router>
+        </div>
+    );
 };
 
 export default App;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,5 @@
 import React, { FC } from 'react';
-
-import logo from './logo.svg';
 import SimpleGet from './Components/SimpleGetRequestTemplate';
-
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
 
 import './App.css';
@@ -19,7 +16,6 @@ const App: FC = () => {
                 <header>
                     <nav className='nav'>
                         <Link to='/'>
-                            {' '}
                             <img src={logoImage} alt='logo' />
                         </Link>
                         <Link to='/'> Hem </Link>

--- a/frontend/src/Components/SimpleGetRequestTemplate.tsx
+++ b/frontend/src/Components/SimpleGetRequestTemplate.tsx
@@ -1,25 +1,25 @@
-import React, { FC, useState } from "react";
-import axios from "axios";
+import React, { FC, useState } from 'react';
+import axios from 'axios';
 
 const GetTemplate: FC = () => {
-  const [responses, setResponses] = useState<string[]>([]);
-  const get = async () => {
-    const res = await axios.get("https://localhost:7156/Template");
-    const data = res.data;
-    console.log(data);
-    setResponses((u) => (u = data));
-  };
+    const [responses, setResponses] = useState<string[]>([]);
+    const get = async () => {
+        const res = await axios.get('https://localhost:7156/Template');
+        const data = res.data;
+        console.log(data);
+        setResponses((u) => (u = data));
+    };
 
-  return (
-    <div className="GetTemplate">
-      <button onClick={get}>click get</button>
-      <ul>
-        {responses.map((txt) => (
-          <li>{txt}</li>
-        ))}
-      </ul>
-    </div>
-  );
+    return (
+        <div className='GetTemplate'>
+            <button onClick={get}>click get</button>
+            <ul>
+                {responses.map((txt, index) => (
+                    <li key={index}>{txt}</li>
+                ))}
+            </ul>
+        </div>
+    );
 };
 
 export default GetTemplate;

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -1,10 +1,20 @@
 const Home = () => (
-  <div className="home">
-    <div className="home-message">
-      <h3>Välkommen </h3>
-      <p >Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Mattis nunc sed blandit libero. Arcu ac tortor dignissim convallis aenean et tortor. Commodo sed egestas egestas fringilla phasellus faucibus scelerisque eleifend donec. Eget egestas purus viverra accumsan in nisl nisi. Aliquet enim tortor at auctor urna nunc id cursus metus. Penatibus et magnis dis parturient montes nascetur. Vitae aliquet nec ullamcorper sit amet. Vitae sapien pellentesque habitant morbi tristique senectus et netus et. Eu facilisis sed odio morbi quis commodo odio aenean. Hendrerit gravida rutrum quisque non. Dui vivamus arcu felis bibendum ut tristique et. Lorem mollis aliquam ut porttitor leo a diam. Morbi non arcu risus quis varius quam quisque.</p>
+    <div className='home'>
+        <div className='home-message'>
+            <h3>Välkommen </h3>
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+                incididunt ut labore et dolore magna aliqua. Mattis nunc sed blandit libero. Arcu ac
+                tortor dignissim convallis aenean et tortor. Commodo sed egestas egestas fringilla
+                phasellus faucibus scelerisque eleifend donec. Eget egestas purus viverra accumsan
+                in nisl nisi. Aliquet enim tortor at auctor urna nunc id cursus metus. Penatibus et
+                magnis dis parturient montes nascetur. Vitae aliquet nec ullamcorper sit amet. Vitae
+                sapien pellentesque habitant morbi tristique senectus et netus et. Eu facilisis sed
+                odio morbi quis commodo odio aenean. Hendrerit gravida rutrum quisque non. Dui
+                vivamus arcu felis bibendum ut tristique et. Lorem mollis aliquam ut porttitor leo a
+                diam. Morbi non arcu risus quis varius quam quisque.
+            </p>
+        </div>
     </div>
-
-  </div>
-)
-export default Home
+);
+export default Home;

--- a/frontend/src/components/MyCourses.tsx
+++ b/frontend/src/components/MyCourses.tsx
@@ -1,10 +1,20 @@
 const MyCourses = () => (
-  <div className="courses">
-    <div className="courses-message">
-      <h3>Mina kurser </h3>
-      <p >Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Mattis nunc sed blandit libero. Arcu ac tortor dignissim convallis aenean et tortor. Commodo sed egestas egestas fringilla phasellus faucibus scelerisque eleifend donec. Eget egestas purus viverra accumsan in nisl nisi. Aliquet enim tortor at auctor urna nunc id cursus metus. Penatibus et magnis dis parturient montes nascetur. Vitae aliquet nec ullamcorper sit amet. Vitae sapien pellentesque habitant morbi tristique senectus et netus et. Eu facilisis sed odio morbi quis commodo odio aenean. Hendrerit gravida rutrum quisque non. Dui vivamus arcu felis bibendum ut tristique et. Lorem mollis aliquam ut porttitor leo a diam. Morbi non arcu risus quis varius quam quisque.</p>
+    <div className='courses'>
+        <div className='courses-message'>
+            <h3>Mina kurser </h3>
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+                incididunt ut labore et dolore magna aliqua. Mattis nunc sed blandit libero. Arcu ac
+                tortor dignissim convallis aenean et tortor. Commodo sed egestas egestas fringilla
+                phasellus faucibus scelerisque eleifend donec. Eget egestas purus viverra accumsan
+                in nisl nisi. Aliquet enim tortor at auctor urna nunc id cursus metus. Penatibus et
+                magnis dis parturient montes nascetur. Vitae aliquet nec ullamcorper sit amet. Vitae
+                sapien pellentesque habitant morbi tristique senectus et netus et. Eu facilisis sed
+                odio morbi quis commodo odio aenean. Hendrerit gravida rutrum quisque non. Dui
+                vivamus arcu felis bibendum ut tristique et. Lorem mollis aliquam ut porttitor leo a
+                diam. Morbi non arcu risus quis varius quam quisque.
+            </p>
+        </div>
     </div>
-
-  </div>
-)
-export default MyCourses
+);
+export default MyCourses;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,13 +1,11 @@
 body {
-  margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
-    sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
+        'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
-    monospace;
+    font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -4,13 +4,11 @@ import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 
-const root = ReactDOM.createRoot(
-  document.getElementById('root') as HTMLElement
-);
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
+    <React.StrictMode>
+        <App />
+    </React.StrictMode>,
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,16 +1,12 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App'
-import { BrowserRouter } from 'react-router-dom'
-
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import { BrowserRouter } from 'react-router-dom';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <BrowserRouter>
-
-      <App />
-
-
-    </BrowserRouter>
-  </React.StrictMode>
-)
+    <React.StrictMode>
+        <BrowserRouter>
+            <App />
+        </BrowserRouter>
+    </React.StrictMode>,
+);

--- a/frontend/src/reportWebVitals.ts
+++ b/frontend/src/reportWebVitals.ts
@@ -1,15 +1,15 @@
 import { ReportHandler } from 'web-vitals';
 
 const reportWebVitals = (onPerfEntry?: ReportHandler) => {
-  if (onPerfEntry && onPerfEntry instanceof Function) {
-    import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
-      getCLS(onPerfEntry);
-      getFID(onPerfEntry);
-      getFCP(onPerfEntry);
-      getLCP(onPerfEntry);
-      getTTFB(onPerfEntry);
-    });
-  }
+    if (onPerfEntry && onPerfEntry instanceof Function) {
+        import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
+            getCLS(onPerfEntry);
+            getFID(onPerfEntry);
+            getFCP(onPerfEntry);
+            getLCP(onPerfEntry);
+            getTTFB(onPerfEntry);
+        });
+    }
 };
 
 export default reportWebVitals;


### PR DESCRIPTION
Initiera ESLint och Prettier på frontend.

Inställningar för kodstandard etc. får ändras efter hur vi vill ha det.

Två nya npm scripts för att kolla och formattera koden i frontend:
- `npm run lint` - För att kolla om koden "klarar" kraven.
- `npm run format` - Formatterar hela frontend efter .prettierrc

GitHub Actions för att kolla så koden är formatterad efter config samt kolla så ESLint reglerna följs.